### PR TITLE
Use `#to_unsafe` to get the pointer to deal with librpm C API.

### DIFF
--- a/spec/spec_rpm.cr
+++ b/spec/spec_rpm.cr
@@ -1255,35 +1255,10 @@ describe RPM::Problem do
     end
   end
 
-  describe ".new from Existing pointer" do
-    it "has same key" do
-      problem = RPM::Problem.new(RPM::ProblemType::REQUIRES, "bar-1.0-0", "foo.rpm", nil, "", "  Hello", 0)
-      problem2 = RPM::Problem.new(problem.ptr)
-      problem2.key.should eq(problem.key)
-    end
-
-    it "has same type" do
-      problem = RPM::Problem.new(RPM::ProblemType::REQUIRES, "bar-1.0-0", "foo.rpm", nil, "", "  Hello", 0)
-      problem2 = RPM::Problem.new(problem.ptr)
-      problem2.type.should eq(problem.type)
-    end
-
-    it "has same str" do
-      problem = RPM::Problem.new(RPM::ProblemType::REQUIRES, "bar-1.0-0", "foo.rpm", nil, "", "  Hello", 0)
-      problem2 = RPM::Problem.new(problem.ptr)
-      problem2.str.should eq(problem.str)
-    end
-
-    it "has same description" do
-      problem = RPM::Problem.new(RPM::ProblemType::REQUIRES, "bar-1.0-0", "foo.rpm", nil, "", "  Hello", 0)
-      problem2 = RPM::Problem.new(problem.ptr)
-      problem2.to_s.should eq(problem.to_s)
-    end
-
+  describe "#dup" do
     it "can duplicate" do
       problem = RPM::Problem.new(RPM::ProblemType::REQUIRES, "bar-1.0-0", "foo.rpm", nil, "", "  Hello", 0)
-      problem2 = RPM::Problem.new(problem.ptr)
-      d = problem2.dup
+      d = problem.dup
       d.key.should eq(problem.key)
     end
   end

--- a/src/rpm/fd.cr
+++ b/src/rpm/fd.cr
@@ -1,6 +1,6 @@
 module RPM
   class FileDescriptor
-    getter fd : LibRPM::FD
+    @fd : LibRPM::FD
     @open : Bool
 
     def self.open(file, mode)
@@ -39,6 +39,11 @@ module RPM
 
     def finalize
       close
+    end
+
+    # Returns pointer to `FD_t` to deal with librpm C API directly.
+    def to_unsafe
+      @fd
     end
   end
 end

--- a/src/rpm/match_iterator.cr
+++ b/src/rpm/match_iterator.cr
@@ -62,5 +62,10 @@ module RPM
     def version(*args)
       set_iterator_version(*args)
     end
+
+    # Returns pointer to `rpmdbMatchIterator` to deal with librpm C API directly
+    def to_unsafe
+      @ptr
+    end
   end
 end

--- a/src/rpm/package.cr
+++ b/src/rpm/package.cr
@@ -14,7 +14,7 @@ module RPM
   end
 
   class Package
-    getter hdr : LibRPM::Header
+    @hdr : LibRPM::Header
 
     # Creates a new package header with given name and version
     def self.create(name : String, version : Version)
@@ -347,6 +347,11 @@ module RPM
           nil
         end
       end
+    end
+
+    # Returns pointer to `header` to deal with librpm C API directly.
+    def to_unsafe
+      @hdr
     end
   end
 end

--- a/src/rpm/problem.cr
+++ b/src/rpm/problem.cr
@@ -57,7 +57,7 @@ module RPM
   #
   class Problem
     @need_gc : Bool = true
-    property ptr : LibRPM::Problem
+    @ptr : LibRPM::Problem
 
     def finalize
       if @need_gc
@@ -123,7 +123,12 @@ module RPM
     end
 
     def <=>(other)
-      LibRPM.rpmProblemCompare(@ptr, other.ptr)
+      LibRPM.rpmProblemCompare(@ptr, other.@ptr)
+    end
+
+    # Returns pointer to `rpmProblem` to deal with librpm C API directly
+    def to_unsafe
+      @ptr
     end
   end
 
@@ -147,24 +152,29 @@ module RPM
     def finalize
       @iter = LibRPM.rpmpsFreeIterator(@iter)
     end
+
+    # Returns pointer to `rpmpsi` to deal with librpm C API directly
+    def to_unsafe
+      @iter
+    end
   end
 
   # Set of Problems
   class ProblemSet
     include Iterable(Problem)
 
-    property ptr : LibRPM::ProblemSet
+    @ptr : LibRPM::ProblemSet
 
     def initialize(@ptr)
     end
 
     def each
-      iter = LibRPM.rpmpsInitIterator(self.ptr)
+      iter = LibRPM.rpmpsInitIterator(@ptr)
       ProblemSetIterator.new(self, iter)
     end
 
     def each(&block)
-      iter = LibRPM.rpmpsInitIterator(self.ptr)
+      iter = LibRPM.rpmpsInitIterator(@ptr)
       begin
         while LibRPM.rpmpsNextIterator(iter) >= 0
           yield Problem.new(LibRPM.rpmpsGetProblem(iter))
@@ -178,6 +188,11 @@ module RPM
       unless @ptr.null?
         @ptr = LibRPM.rpmpsFree(@ptr)
       end
+    end
+
+    # Returns pointer to `rpmps` to deal with librpm C API directly
+    def to_unsafe
+      @ptr
     end
   end
 end

--- a/src/rpm/tagdata.cr
+++ b/src/rpm/tagdata.cr
@@ -704,5 +704,10 @@ module RPM
       @ptr = type.new(@ptr)
       cls
     end
+
+    # Returns pointer to `rpmtd` to deal with librpm C API directly.
+    def to_unsafe
+      @ptr.to_unsafe
+    end
   end
 end

--- a/src/rpm/transaction.cr
+++ b/src/rpm/transaction.cr
@@ -210,7 +210,7 @@ module RPM
     # will be raised when some error occured.
     def delete_by_iterator(iter : MatchIterator)
       iter.each do |header|
-        ret = LibRPM.rpmtsAddEraseElement(@ptr, header.hdr, iter.offset)
+        ret = LibRPM.rpmtsAddEraseElement(@ptr, header, iter.offset)
         raise TransactionError.new("Error while adding erase to transaction") if ret != 0
       end
     end
@@ -302,7 +302,7 @@ module RPM
       raise Exception.new("key #{key} must be unique") if @keys.includes?(key)
       @keys << key
 
-      ret = LibRPM.rpmtsAddInstallElement(@ptr, pkg.hdr, key, upgrade, nil)
+      ret = LibRPM.rpmtsAddInstallElement(@ptr, pkg, key, upgrade, nil)
       raise TransactionError.new("Failed add install element") if ret != 0
       nil
     end
@@ -375,7 +375,7 @@ module RPM
             end
             fdt = FileDescriptor.for_fd(ino)
             boxed.fdt = fdt
-            fdt.fd.as(Pointer(Void))
+            fdt.to_unsafe.as(Pointer(Void))
           when CallbackType::INST_CLOSE_FILE
             if boxed.fdt
               fd = boxed.fdt.as(FileDescriptor)
@@ -454,6 +454,11 @@ module RPM
     # different by RPM version.
     def commit(&block : Callback)
       commit(block)
+    end
+
+    # Returns pointer to `rpmts` to
+    def to_unsafe
+      @ptr
     end
   end
 

--- a/src/rpm/transaction_element.cr
+++ b/src/rpm/transaction_element.cr
@@ -147,7 +147,8 @@ struct RPM::Transaction::Element
     LibRPM.rpmteFailed(@ptr) != 0
   end
 
-  private def ptr
+  # Returns pointer to `rpmte` to deal with librpm C API directly
+  def to_unsafe
     @ptr
   end
 end


### PR DESCRIPTION
Invented `#to_unsafe` to get the pointer to deal with librpm C API directly.