### PR TITLE
Fix warning for crystal-0.31-dev

### DIFF
--- a/src/rpm/tagdata.cr
+++ b/src/rpm/tagdata.cr
@@ -182,7 +182,7 @@ module RPM
       include ReturnTypeModule
 
       # :nodoc:
-      def fetch_ptr
+      def fetch_ptr : Pointer(UInt16)
         LibRPM.rpmtdGetUint16(@ptr)
       end
 
@@ -203,7 +203,7 @@ module RPM
       include ReturnTypeModule
 
       # :nodoc:
-      def fetch_ptr
+      def fetch_ptr : Pointer(UInt32)
         LibRPM.rpmtdGetUint32(@ptr)
       end
 
@@ -224,7 +224,7 @@ module RPM
       include ReturnTypeModule
 
       # :nodoc:
-      def fetch_ptr
+      def fetch_ptr : Pointer(UInt64)
         LibRPM.rpmtdGetUint64(@ptr)
       end
 
@@ -289,7 +289,7 @@ module RPM
       end
 
       # :nodoc:
-      def fetch_ptr
+      def fetch_ptr : Pointer(UInt8)
         LibRPM.rpmtdGetChar(@ptr)
       end
     end


### PR DESCRIPTION
Crystal 0.31-dev complains about the return type of `abstract fetch_ptr`.

```
> ~/crystal/bin/crystal -v
Using compiled compiler at `.build/crystal'
Crystal 0.31.0-dev [b3d32e93b] (2019-09-21)

LLVM: 6.0.1
Default target: x86_64-unknown-linux-gnu
> fakechroot ~/crystal/bin/crystal spec -v
Using compiled compiler at `.build/crystal'
"/usr/bin/cc"  -DVERSION_MAJOR=4 -DVERSION_MINOR=14 -DVERSION_PATCH=2 -c -o "/home/lugia/crystal-rpm/spec/c-check.o" ./spec/c-check.c
In src/rpm/tagdata.cr:185:11

 185 | def fetch_ptr
           ^--------
Warning: this method overrides RPM::TagData::ReturnType(T)#fetch_ptr() which has an explicit return type of Pointer(T).

Please add an explicit return type (Pointer(UInt16) or a subtype of it) to this method as well.

The above warning will become an error in a future Crystal version.

In src/rpm/tagdata.cr:206:11

 206 | def fetch_ptr
           ^--------
Warning: this method overrides RPM::TagData::ReturnType(T)#fetch_ptr() which has an explicit return type of Pointer(T).

Please add an explicit return type (Pointer(UInt32) or a subtype of it) to this method as well.

The above warning will become an error in a future Crystal version.

In src/rpm/tagdata.cr:227:11

 227 | def fetch_ptr
           ^--------
Warning: this method overrides RPM::TagData::ReturnType(T)#fetch_ptr() which has an explicit return type of Pointer(T).

Please add an explicit return type (Pointer(UInt64) or a subtype of it) to this method as well.

The above warning will become an error in a future Crystal version.

A total of 3 warnings were found.
helper
  #rpm
    runs rpm
    raises RPMCLIExceptionFailed on failure
    sets $? (without block)
... (omit)
```
