### PR TITLE
Add support to passing HeaderGetFlags for Package#with_tagdata.

### DIFF
--- a/src/rpm/librpm.cr
+++ b/src/rpm/librpm.cr
@@ -1174,6 +1174,8 @@ module RPM
   alias TagReturnType = LibRPM::TagReturnType
   alias DbiTag = LibRPM::DbiTag
   alias DbiTagValue = LibRPM::DbiTagVal
+  alias HeaderGetFlags = LibRPM::HeaderGetFlags
+  alias HeaderPutFlags = LibRPM::HeaderPutFlags
   alias FileState = LibRPM::FileState
   alias FileAttrs = LibRPM::FileAttrs
   alias CallbackType = LibRPM::CallbackType


### PR DESCRIPTION
- Add HeaderGetFlags::EXT for Package#[] and Package#[]?, to become
  able to get ext data (such as NEVR, NEVRA, etc.)