### PR TITLE
Fix cookie in build flags has not been set.

### DIFF
--- a/src/rpm/spec.cr
+++ b/src/rpm/spec.cr
@@ -245,6 +245,7 @@ module RPM
         xflags.build_amount = build_amount
         xflags.build_root = buildroot.to_unsafe
         xflags.rootdir = rootdir ? rootdir.to_unsafe : null
+        xflags.cookie = null
         pflags = pointerof(xflags).as(LibRPM::BuildArguments)
         rc = LibRPM.rpmSpecBuild(@ptr, pflags)
         if rc == LibRPM::RC::OK


### PR DESCRIPTION
```crystal
uninitialized Foo
```
can be initialized without zero-ing.

I could not find a confident reference about this, but they seem to want to say that.