### PR TITLE
Fix rpmtsFree does not seem to free Spec.

### DIFF
--- a/src/rpm/librpm.cr
+++ b/src/rpm/librpm.cr
@@ -1158,6 +1158,7 @@ module RPM
     fun rpmtsSpec(Transaction) : Spec
     # fun build(Transaction, UInt8*, BuildArguments, UInt8*) : Int
     fun buildSpec(Transaction, Spec, Int, Int) : RC
+    fun freeSpec(Spec)
 
     # RPM 4.9 APIs.
     @[Flags]

--- a/src/rpm/spec.cr
+++ b/src/rpm/spec.cr
@@ -288,6 +288,7 @@ module RPM
     # Cleanup
     def finalize
       {% if compare_versions(PKGVERSION_COMP, "4.9.0") < 0 %}
+        LibRPM.freeSpec(@ptr)
         LibRPM.rpmtsFree(@ts)
       {% else %}
         LibRPM.rpmSpecFree(@ptr)


### PR DESCRIPTION
According to this patch for ruby-rpm it says that `rpmtsFree()` won't free the `Spec` data bound to the transaction.
```diff
diff -up ruby-rpm-1.2.3/ext/rpm/db.c.memleak~ ruby-rpm-1.2.3/ext/rpm/db.c
--- ruby-rpm-1.2.3/ext/rpm/db.c.memleak~	2008-06-01 17:50:50.000000000 +0900
+++ ruby-rpm-1.2.3/ext/rpm/db.c	2008-06-01 17:50:34.000000000 +0900
@@ -268,6 +268,7 @@ transaction_free(rpm_trans_t* trans)
 #if RPM_VERSION_CODE < RPM_VERSION(4,1,0)
 	rpmtransFree(trans->ts);
 #else
+	freeSpec(rpmtsSpec(trans->ts));
 	rpmtsFree(trans->ts);
 #endif
 	db_unref(trans->db);
diff -up ruby-rpm-1.2.3/ext/rpm/rpm40_compat.c.memleak~ ruby-rpm-1.2.3/ext/rpm/rpm40_compat.c
diff -up ruby-rpm-1.2.3/ext/rpm/spec.c.memleak~ ruby-rpm-1.2.3/ext/rpm/spec.c
--- ruby-rpm-1.2.3/ext/rpm/spec.c.memleak~	2008-06-01 17:49:31.000000000 +0900
+++ ruby-rpm-1.2.3/ext/rpm/spec.c	2008-06-01 17:51:28.000000000 +0900
@@ -28,6 +28,7 @@ spec_free(Spec rspec)
 static void
 ts_free(rpmts ts)
 {
+	freeSpec(rpmtsSpec(ts));
 	ts = rpmtsFree(ts);
 }
```

I did not confirm with the RPM 4.8 source, but it seems to be harmless.

